### PR TITLE
Update compose 1.12.0-rc2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.10.0-rc1.{build}
+version: 1.12.0-rc2.{build}
 environment:
   TOKEN:
     secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66

--- a/docker-compose.nuspec
+++ b/docker-compose.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>docker-compose</id>
-    <version>1.10.0-rc1</version>
+    <version>1.12.0-rc2</version>
     <title>docker-compose</title>
     <authors>Docker Contributors</authors>
     <owners>Stefan Scherer</owners>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 $packageName = 'docker-compose'
-$url = 'https://github.com/docker/compose/releases/download/1.10.0-rc1/docker-compose-Windows-x86_64.exe'
+$url = 'https://github.com/docker/compose/releases/download/1.12.0-rc2/docker-compose-Windows-x86_64.exe'
 $url64 = $url
-$checksum = '185f65e4e66e7573dad37604e7688edf'
+$checksum = '4de1bec142705060fcc6b9197caff3d7'
 $checksum64 = $checksum
 $checksumType = 'md5'
 $checksumType64 = $checksumType


### PR DESCRIPTION
Update docker-compose 1.12.0-rc2, first version supporting compose yml version 3.2
