### PR TITLE
Switch to Docker Compose V2

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -34,7 +34,7 @@ variables below.
 
 Example:
 
-$url            = 'https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Windows-x86_64.exe'
+$url            = 'https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-Windows-x86_64.exe'
 
 #### 4. Update appveyor.yml
 
@@ -50,7 +50,7 @@ Push your changes to GitHub and check the AppVeyor build. See the AppVeyor build
 
 After a successfull AppVeyor build tag the sources and push the new tag to GitHub. This step builds and tests the package and pushes the new package to Chocolatey.
 
-    git tag 1.6.2
+    git tag 2.15.1
     git push --tags
 
 ## AppVeyor build

--- a/README.md
+++ b/README.md
@@ -13,5 +13,3 @@ flag also if it hasn't gone through moderation).
 # Links
 
 * https://github.com/docker/compose - docker-compose
-* https://github.com/silarsis/choco-docker-machine - docker-machine choco package, inspiration for this package
-* https://github.com/ahmetalpbalkan/docker-chocolatey - docker client choco package, inspiration for this package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.29.2.{build}
+version: 2.15.1.{build}
 environment:
   TOKEN:
     secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66

--- a/docker-compose.nuspec
+++ b/docker-compose.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>docker-compose</id>
-    <version>1.29.2</version>
+    <version>2.15.1</version>
     <title>docker-compose</title>
     <authors>Docker Contributors</authors>
     <owners>Stefan Scherer</owners>

--- a/docker-compose.nuspec
+++ b/docker-compose.nuspec
@@ -13,9 +13,9 @@
     <bugTrackerUrl>https://github.com/docker/compose/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/StefanScherer/choco-docker-compose</packageSourceUrl>
     <tags>Docker Compose docker-compose</tags>
-    <licenseUrl>https://github.com/docker/compose/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/docker/compose/blob/v2/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <iconUrl>https://raw.githubusercontent.com/docker/compose/master/logo.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/docker/compose/v2/logo.png</iconUrl>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/test.ps1
+++ b/test.ps1
@@ -5,7 +5,7 @@ $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$')
 "TEST: Version $version in docker-compose.nuspec file should match"
 [xml]$spec = Get-Content docker-compose.nuspec
 if ($spec.package.metadata.version.CompareTo($version)) {
-  Write-Error "FAIL: rong version in nuspec file!"
+  Write-Error "FAIL: Wrong version in nuspec file!"
 }
 
 "TEST: Package should contain only install script"
@@ -21,7 +21,7 @@ $zip.Dispose()
 
 "TEST: Version of binary should match"
 . docker-compose --version
-if (-Not $(docker-compose --version).Contains("version $version")) {
+if (-Not $(docker-compose --version).Contains("version v$version")) {
   Write-Error "FAIL: Wrong version of docker-compose installed!"
 }
 

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $packageName = 'docker-compose'
-$url = 'https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Windows-x86_64.exe'
-$checksum = '94c3c634e21532eb9783057eac5235ca44b3e14a4c34e73d7eb6b94a2544cc12'
+$url = 'https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-windows-x86_64.exe'
+$checksum = '538598025dc9ae41298abf859d5b312fba40359c691d9b14527375f4633cbe65'
 $checksumType = 'sha256'
 
 $destination = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/update.sh
+++ b/update.sh
@@ -15,7 +15,7 @@ fi
 
 version=$1
 
-url="https://github.com/docker/compose/releases/download/${version}/docker-compose-Windows-x86_64.exe"
+url="https://github.com/docker/compose/releases/download/v${version}/docker-compose-windows-x86_64.exe"
 
 checksum=$(curl -Lf "${url}" | shasum -a 256 - | cut -f 1 -d " ")
 


### PR DESCRIPTION
After some time of thinking let's bump this Choco package to Docker Compose V2. Although Compose v2 normally should be a `docker compose` (with a space, using the Docker Compose CLI plugin) instead of `docker-compose` (dash). But installing a CLI plugin via chocolatey could complicate this package, we need to put the executable into a special folder.

So let's just use the executable as a standalone binary `docker-compose`.

BTW: Docker Compose V1 is deprecated and everyone should switch over to Compose V2.
